### PR TITLE
Handle null qty and price in order summary

### DIFF
--- a/force-app/main/default/lwc/orderBuilder/__tests__/orderBuilder.test.js
+++ b/force-app/main/default/lwc/orderBuilder/__tests__/orderBuilder.test.js
@@ -179,6 +179,49 @@ describe('c-order-builder', () => {
         );
     });
 
+    it('calculates summary with null quantities and price', async () => {
+        const partialData = [
+            {
+                Id: '1',
+                Qty_S__c: null,
+                Qty_M__c: 1,
+                Qty_L__c: 1,
+                Price__c: 100,
+                Product__r: {}
+            },
+            {
+                Id: '2',
+                Qty_S__c: 3,
+                Qty_M__c: null,
+                Qty_L__c: null,
+                Price__c: null,
+                Product__r: {}
+            }
+        ];
+        const expectedItems = 5;
+        const expectedSum = 200;
+
+        const element = createElement('c-order-builder', {
+            is: OrderBuilder
+        });
+        element.recordId = mockRecordId;
+        document.body.appendChild(element);
+
+        getOrderItems.emit(partialData);
+
+        await flushPromises();
+
+        const formattedNumberEl = element.shadowRoot.querySelector(
+            'lightning-formatted-number'
+        );
+        expect(formattedNumberEl.value).toBe(expectedSum);
+
+        const orderTotalDivEl = element.shadowRoot.querySelector('div.right');
+        expect(orderTotalDivEl.textContent).toBe(
+            `Total Items: ${expectedItems}`
+        );
+    });
+
     it('displays a panel when no data is returned', async () => {
         // Set values for validating component changes
         const expectedMessage = 'Drag products here to add items to the order';

--- a/force-app/main/default/lwc/orderBuilder/orderBuilder.js
+++ b/force-app/main/default/lwc/orderBuilder/orderBuilder.js
@@ -32,18 +32,19 @@ const DISCOUNT = 0.6;
  * Gets the quantity of all items in an Order_Item__c SObject.
  */
 function getQuantity(orderItem) {
-    return (
-        getSObjectValue(orderItem, QTY_SMALL_FIELD) +
-        getSObjectValue(orderItem, QTY_MEDIUM_FIELD) +
-        getSObjectValue(orderItem, QTY_LARGE_FIELD)
-    );
+    const qtyS = getSObjectValue(orderItem, QTY_SMALL_FIELD);
+    const qtyM = getSObjectValue(orderItem, QTY_MEDIUM_FIELD);
+    const qtyL = getSObjectValue(orderItem, QTY_LARGE_FIELD);
+
+    return (qtyS ?? 0) + (qtyM ?? 0) + (qtyL ?? 0);
 }
 
 /**
  * Gets the price for the specified quantity of Order_Item__c SObject.
  */
 function getPrice(orderItem, quantity) {
-    return getSObjectValue(orderItem, PRICE_FIELD) * quantity;
+    const price = getSObjectValue(orderItem, PRICE_FIELD);
+    return (price ?? 0) * quantity;
 }
 
 /**


### PR DESCRIPTION
## Summary
- default missing quantity fields to `0`
- default missing price to `0`
- test order summary with missing fields

## Testing
- `npm test` *(fails: sfdx-lwc-jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fa4b43da083299235dc368a5e6a69