### PR TITLE
Add unsubscribe test for EMP API

### DIFF
--- a/force-app/main/default/lwc/orderStatusPath/__tests__/orderStatusPath.test.js
+++ b/force-app/main/default/lwc/orderStatusPath/__tests__/orderStatusPath.test.js
@@ -2,7 +2,13 @@ import { createElement } from 'lwc';
 import OrderStatusPath from 'c/orderStatusPath';
 import { getObjectInfo, getPicklistValues } from 'lightning/uiObjectInfoApi';
 import { getRecord, updateRecord } from 'lightning/uiRecordApi';
-import { isEmpEnabled, onError, subscribe, empApiMock } from 'lightning/empApi';
+import {
+    isEmpEnabled,
+    onError,
+    subscribe,
+    unsubscribe,
+    empApiMock
+} from 'lightning/empApi';
 
 // Mock realistic data
 const mockGetObjectInfo = require('./data/getObjectInfo.json');
@@ -250,6 +256,26 @@ describe('c-order-status-path', () => {
             );
             expect(errorItem).not.toBeNull();
             expect(errorItem.textContent).toMatch(/failed to subscribe/);
+        });
+
+        it('unsubscribes when the component is removed from the DOM', async () => {
+            const element = createElement('c-order-status-path', {
+                is: OrderStatusPath
+            });
+            document.body.appendChild(element);
+
+            // Emit data from @wire
+            getObjectInfo.emit(mockGetObjectInfo);
+            getPicklistValues.emit(mockGetPicklistValues);
+            getRecord.emit(mockGetRecord);
+
+            // Wait for subscription to be set
+            await flushPromises();
+
+            // Remove element to trigger disconnectedCallback
+            document.body.removeChild(element);
+
+            expect(unsubscribe).toHaveBeenCalled();
         });
     });
 

--- a/force-app/test/jest-mocks/lightning/empApi.js
+++ b/force-app/test/jest-mocks/lightning/empApi.js
@@ -17,7 +17,8 @@ const subscribe = jest.fn((channel, replayId, callback) => {
         return Promise.reject(_mockSubscribeError);
     }
     _mockSubscribeCallback = callback;
-    return Promise.resolve();
+    // Return a subscription object similar to the real API
+    return Promise.resolve({ channel });
 });
 
 const unsubscribe = jest.fn(() => {});


### PR DESCRIPTION
## Summary
- improve EMP API mock to return a subscription object
- test that `<c-order-status-path>` unsubscribes when removed from the DOM

## Testing
- `npm test` *(fails: sfdx-lwc-jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fa495c6a88329aa90eccb33907881