### PR TITLE
Fix tour description typo

### DIFF
--- a/.tours/-welcome-to-e-bikes.tour
+++ b/.tours/-welcome-to-e-bikes.tour
@@ -11,7 +11,7 @@
     {
       "title": "Property Explorer - Lightning Message Service",
       "file": "force-app/main/default/lwc/productTileList/productTileList.js",
-      "description": "The LWC uses Lightning Message Service to publish a selected product using the `PRODUCT_SELECTED_MESSAGE` [Lightning message channel](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.use_message_channel). This way, any components subscribing to the message will recieve the data when it is published.",
+      "description": "This component publishes the selected product using the `PRODUCT_SELECTED_MESSAGE` Lightning message channel. Subscribing components receive the data when it's published.",
       "line": 62
     },
     {


### PR DESCRIPTION
## Summary
- fix minor typo in welcome tour
- add newline at end of welcome tour file
- simplify message service step description

## Testing
- `npm test` *(fails: sfdx-lwc-jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fa4bce0848329a4e589d5832f9722